### PR TITLE
Serve jquery over https

### DIFF
--- a/watchapp/configurable.html
+++ b/watchapp/configurable.html
@@ -4,9 +4,9 @@
     <title>Configurable</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="http://code.jquery.com/mobile/1.3.2/jquery.mobile-1.3.2.min.css" />
-    <script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
-    <script src="http://code.jquery.com/mobile/1.3.2/jquery.mobile-1.3.2.min.js"></script>
+    <link rel="stylesheet" href="https://code.jquery.com/mobile/1.3.2/jquery.mobile-1.3.2.min.css" />
+    <script src="https://code.jquery.com/jquery-1.9.1.min.js"></script>
+    <script src="https://code.jquery.com/mobile/1.3.2/jquery.mobile-1.3.2.min.js"></script>
 
     <script type="text/javascript">
 


### PR DESCRIPTION
The configuration dialog is not working on android M.

Loading https://pebble-mars-images.s3.amazonaws.com/configurable.html in desktop chromium shows why:

Mixed Content: The page at 'https://pebble-mars-images.s3.amazonaws.com/configurable.html' was loaded over HTTPS, but requested an insecure stylesheet 'http://code.jquery.com/mobile/1.3.2/jquery.mobile-1.3.2.min.css'. This request has been blocked; the content must be served over HTTPS.
Mixed Content: The page at 'https://pebble-mars-images.s3.amazonaws.com/configurable.html' was loaded over HTTPS, but requested an insecure script 'http://code.jquery.com/jquery-1.9.1.min.js'. This request has been blocked; the content must be served over HTTPS.
Mixed Content: The page at 'https://pebble-mars-images.s3.amazonaws.com/configurable.html' was loaded over HTTPS, but requested an insecure script 'http://code.jquery.com/mobile/1.3.2/jquery.mobile-1.3.2.min.js'. This request has been blocked; the content must be served over HTTPS.
Uncaught ReferenceError: $ is not defined
